### PR TITLE
Gcc bug 10676 fixes

### DIFF
--- a/lv_apps/benchmark/benchmark_bg.c
+++ b/lv_apps/benchmark/benchmark_bg.c
@@ -176,12 +176,16 @@ static const uint8_t benchmark_bg_pixel_map[] = {
 
 
 const lv_img_t benchmark_bg = {
+    {
     .header.w = 50,           /*Image width in pixel count*/
     .header.h = 50,           /*Image height in pixel count*/
     .header.alpha_byte = 0,       /*No alpha byte*/
     .header.chroma_keyed = 0, /*No chroma keying*/
     .header.format = LV_IMG_FORMAT_INTERNAL_RAW,  /*It's a variable compiled into the code*/
+    },
+    {
     .pixel_map = benchmark_bg_pixel_map   /*Pointer the array of image pixels.*/
+    }
 };
 
 #endif

--- a/lv_apps/benchmark/benchmark_bg.c
+++ b/lv_apps/benchmark/benchmark_bg.c
@@ -177,14 +177,14 @@ static const uint8_t benchmark_bg_pixel_map[] = {
 
 const lv_img_t benchmark_bg = {
     {
-    .header.w = 50,           /*Image width in pixel count*/
-    .header.h = 50,           /*Image height in pixel count*/
-    .header.alpha_byte = 0,       /*No alpha byte*/
-    .header.chroma_keyed = 0, /*No chroma keying*/
-    .header.format = LV_IMG_FORMAT_INTERNAL_RAW,  /*It's a variable compiled into the code*/
+        .header.w = 50,           /*Image width in pixel count*/
+        .header.h = 50,           /*Image height in pixel count*/
+        .header.alpha_byte = 0,       /*No alpha byte*/
+        .header.chroma_keyed = 0, /*No chroma keying*/
+        .header.format = LV_IMG_FORMAT_INTERNAL_RAW,  /*It's a variable compiled into the code*/
     },
     {
-    .pixel_map = benchmark_bg_pixel_map   /*Pointer the array of image pixels.*/
+        .pixel_map = benchmark_bg_pixel_map   /*Pointer the array of image pixels.*/
     }
 };
 

--- a/lv_ex_conf_templ.h
+++ b/lv_ex_conf_templ.h
@@ -12,7 +12,7 @@
  * GENERAL SETTING
  *******************/
 #define LV_EX_PRINTF    0       /*Enable printf-ing data*/
-#define LV_EX_KEYBOARD	0		/*Add PC keyboard support to some examples (`lv_drvers` repository is required)*/
+#define LV_EX_KEYBOARD  0       /*Add PC keyboard support to some examples (`lv_drvers` repository is required)*/
 
 /*******************
  *   TEST USAGE

--- a/lv_tests/lv_test_group/lv_test_group.c
+++ b/lv_tests/lv_test_group/lv_test_group.c
@@ -194,7 +194,7 @@ void lv_test_group_1(void)
     lv_group_add_obj(g, obj);
     obj = lv_label_create(obj, NULL);
     lv_label_set_text(obj, "I'm a page\nwith a long \ntext.\n\n"
-    		               "You can try \nto scroll me\nwith UP and DOWN\nbuttons.");
+                      "You can try \nto scroll me\nwith UP and DOWN\nbuttons.");
     lv_label_set_align(obj, LV_LABEL_ALIGN_CENTER);
 
     obj = lv_lmeter_create(win, NULL);
@@ -204,7 +204,7 @@ void lv_test_group_1(void)
 #if LV_COMPILER_NON_CONST_INIT_SUPPORTED
     static lv_color_t needle_color[] = {LV_COLOR_RED};
 #else
-	static lv_color_t needle_color[] = { 0 };
+    static lv_color_t needle_color[] = { 0 };
 #endif
     obj = lv_gauge_create(win, NULL);
     lv_gauge_set_needle_count(obj, 1, needle_color);

--- a/lv_tests/lv_test_obj/lv_test_obj.c
+++ b/lv_tests/lv_test_obj/lv_test_obj.c
@@ -74,7 +74,7 @@ void lv_test_object_1(void)
 
     /*Create a parent and 3 objects on it. Hide the parent but move 2 children to the screen*/
 
-    lv_obj_t *obj4_parent = lv_obj_create(lv_scr_act(), NULL);
+    lv_obj_t * obj4_parent = lv_obj_create(lv_scr_act(), NULL);
     lv_obj_set_pos(obj4_parent, lv_obj_get_x(obj1) + 10, lv_obj_get_y(obj1) + lv_obj_get_height(obj1) + 20);
     lv_obj_set_style(obj4_parent, &lv_style_pretty_color);
     lv_obj_set_hidden(obj4_parent, true); /*Hide this and all children objects*/

--- a/lv_tests/lv_test_objx/lv_test_gauge/lv_test_gauge.c
+++ b/lv_tests/lv_test_objx/lv_test_gauge/lv_test_gauge.c
@@ -53,7 +53,7 @@ void lv_test_gauge_1(void)
 #if LV_COMPILER_NON_CONST_INIT_SUPPORTED
     static lv_color_t needle_colors[3] = {LV_COLOR_BLUE, LV_COLOR_PURPLE, LV_COLOR_TEAL};
 #else
-	static lv_color_t needle_colors[3] = { 0, 0, 0 };
+    static lv_color_t needle_colors[3] = { 0, 0, 0 };
 #endif
     /*Create a styled gauge*/
     static lv_style_t style3;

--- a/lv_tests/lv_test_objx/lv_test_img/img_flower_icon.c
+++ b/lv_tests/lv_test_objx/lv_test_img/img_flower_icon.c
@@ -146,12 +146,16 @@ static const uint8_t img_flower_icon_pixel_map[] = {
 
 
 const lv_img_t img_flower_icon = {
+    {
     .header.w = 40,           /*Image width in pixel count*/
     .header.h = 40,           /*Image height in pixel count*/
     .header.alpha_byte = 0,       /*No alpha byte*/
     .header.chroma_keyed = 1, /*LV_COLOR_TRANSP (lv_conf.h) pixels will be transparent*/
     .header.format = LV_IMG_FORMAT_INTERNAL_RAW,
+    },
+    {
     .pixel_map = img_flower_icon_pixel_map /*Pointer the array of image pixels.*/
+    }
 };
 
 #endif

--- a/lv_tests/lv_test_objx/lv_test_img/img_flower_icon.c
+++ b/lv_tests/lv_test_objx/lv_test_img/img_flower_icon.c
@@ -147,14 +147,14 @@ static const uint8_t img_flower_icon_pixel_map[] = {
 
 const lv_img_t img_flower_icon = {
     {
-    .header.w = 40,           /*Image width in pixel count*/
-    .header.h = 40,           /*Image height in pixel count*/
-    .header.alpha_byte = 0,       /*No alpha byte*/
-    .header.chroma_keyed = 1, /*LV_COLOR_TRANSP (lv_conf.h) pixels will be transparent*/
-    .header.format = LV_IMG_FORMAT_INTERNAL_RAW,
+        .header.w = 40,           /*Image width in pixel count*/
+        .header.h = 40,           /*Image height in pixel count*/
+        .header.alpha_byte = 0,       /*No alpha byte*/
+        .header.chroma_keyed = 1, /*LV_COLOR_TRANSP (lv_conf.h) pixels will be transparent*/
+        .header.format = LV_IMG_FORMAT_INTERNAL_RAW,
     },
     {
-    .pixel_map = img_flower_icon_pixel_map /*Pointer the array of image pixels.*/
+        .pixel_map = img_flower_icon_pixel_map /*Pointer the array of image pixels.*/
     }
 };
 

--- a/lv_tutorial/0_porting/lv_tutorial_porting.c
+++ b/lv_tutorial/0_porting/lv_tutorial_porting.c
@@ -234,7 +234,7 @@ static void ex_mem_fill(lv_color_t * dest, uint32_t length, lv_color_t color)
 
 /* Read the touchpad and store it in 'data'
  * Return false if no more data read; true for ready again */
-static bool ex_tp_read(lv_indev_data_t *data)
+static bool ex_tp_read(lv_indev_data_t * data)
 {
     /* Read your touchpad */
     /* data->state = LV_INDEV_STATE_REL or LV_INDEV_STATE_PR */

--- a/lv_tutorial/10_keyboard/lv_tutorial_keyboard.c
+++ b/lv_tutorial/10_keyboard/lv_tutorial_keyboard.c
@@ -53,10 +53,10 @@ static lv_res_t keypad_btn_release(lv_obj_t * btn);
 /**********************
  *  STATIC VARIABLES
  **********************/
-static lv_obj_t * btn_enable;       	/*An enable button*/
-static lv_style_t style_mbox_bg;    	/*Black bg. style with opacity*/
-static lv_group_t * g;              	/*An Object Group*/
-static lv_indev_t * emulated_kp_indev;	/*The input device of the emulated keypad*/
+static lv_obj_t * btn_enable;           /*An enable button*/
+static lv_style_t style_mbox_bg;        /*Black bg. style with opacity*/
+static lv_group_t * g;                  /*An Object Group*/
+static lv_indev_t * emulated_kp_indev;  /*The input device of the emulated keypad*/
 static lv_indev_state_t last_state = LV_INDEV_STATE_REL;
 static uint32_t last_key = 0;
 
@@ -212,7 +212,7 @@ static lv_res_t enable_action(lv_obj_t * btn)
         /* Create a dark screen sized bg. with opacity to show
          * the other objects are not available now*/
         lv_obj_t * bg = lv_obj_create(lv_scr_act(), NULL);
-        lv_obj_set_protect(bg, LV_PROTECT_PARENT);          		/*The page screen moves it to scrollable area*/
+        lv_obj_set_protect(bg, LV_PROTECT_PARENT);                  /*The page screen moves it to scrollable area*/
         lv_obj_set_parent(bg, lv_scr_act());                         /*So move it back when protected*/
         lv_obj_set_style(bg, &style_mbox_bg);
         lv_obj_set_size(bg, LV_HOR_RES, LV_VER_RES);
@@ -268,8 +268,8 @@ static lv_res_t mbox_action(lv_obj_t * btn, const char * txt)
  */
 static lv_res_t keypad_btn_press(lv_obj_t * btn)
 {
-    last_key = lv_obj_get_free_num(btn);	/*Save the key*/
-    last_state = LV_INDEV_STATE_PR;			/*Save the state*/
+    last_key = lv_obj_get_free_num(btn);    /*Save the key*/
+    last_state = LV_INDEV_STATE_PR;         /*Save the state*/
 
     return LV_RES_OK;
 }
@@ -282,7 +282,7 @@ static lv_res_t keypad_btn_press(lv_obj_t * btn)
  */
 static lv_res_t keypad_btn_release(lv_obj_t * btn)
 {
-    last_state = LV_INDEV_STATE_REL;		/*Save the new state but leave the last key*/
+    last_state = LV_INDEV_STATE_REL;        /*Save the new state but leave the last key*/
 
     return LV_RES_OK;
 }

--- a/lv_tutorial/5_antialiasing/apple_icon_alpha.c
+++ b/lv_tutorial/5_antialiasing/apple_icon_alpha.c
@@ -116,12 +116,16 @@ static const uint8_t apple_icon_alpha_pixel_map[] = {
 
 
 const lv_img_t apple_icon_alpha = {
+    {
     .header.w = 30,           /*Image width in pixel count*/
     .header.h = 30,           /*Image height in pixel count*/
     .header.alpha_byte = 1,       /*Alpha byte added to every pixel*/
     .header.chroma_keyed = 0, /*No chroma keying*/
     .header.format = LV_IMG_FORMAT_INTERNAL_RAW,
+    },
+    {
     .pixel_map = apple_icon_alpha_pixel_map,  /*Pointer the array of image pixels.*/
+    }
 };
 
 #endif

--- a/lv_tutorial/5_antialiasing/apple_icon_alpha.c
+++ b/lv_tutorial/5_antialiasing/apple_icon_alpha.c
@@ -117,14 +117,14 @@ static const uint8_t apple_icon_alpha_pixel_map[] = {
 
 const lv_img_t apple_icon_alpha = {
     {
-    .header.w = 30,           /*Image width in pixel count*/
-    .header.h = 30,           /*Image height in pixel count*/
-    .header.alpha_byte = 1,       /*Alpha byte added to every pixel*/
-    .header.chroma_keyed = 0, /*No chroma keying*/
-    .header.format = LV_IMG_FORMAT_INTERNAL_RAW,
+        .header.w = 30,           /*Image width in pixel count*/
+        .header.h = 30,           /*Image height in pixel count*/
+        .header.alpha_byte = 1,       /*Alpha byte added to every pixel*/
+        .header.chroma_keyed = 0, /*No chroma keying*/
+        .header.format = LV_IMG_FORMAT_INTERNAL_RAW,
     },
     {
-    .pixel_map = apple_icon_alpha_pixel_map,  /*Pointer the array of image pixels.*/
+        .pixel_map = apple_icon_alpha_pixel_map,  /*Pointer the array of image pixels.*/
     }
 };
 

--- a/lv_tutorial/5_antialiasing/apple_icon_chroma.c
+++ b/lv_tutorial/5_antialiasing/apple_icon_chroma.c
@@ -117,14 +117,14 @@ static const uint8_t apple_icon_chroma_pixel_map[] = {
 
 const lv_img_t apple_icon_chroma = {
     {
-    .header.w = 30,           /*Image width in pixel count*/
-    .header.h = 30,           /*Image height in pixel count*/
-    .header.alpha_byte = 0,       /*No alpha byte*/
-    .header.chroma_keyed = 1, /*LV_COLOR_TRANSP (lv_conf.h) pixels will be transparent*/
-    .header.format = LV_IMG_FORMAT_INTERNAL_RAW,
+        .header.w = 30,           /*Image width in pixel count*/
+        .header.h = 30,           /*Image height in pixel count*/
+        .header.alpha_byte = 0,       /*No alpha byte*/
+        .header.chroma_keyed = 1, /*LV_COLOR_TRANSP (lv_conf.h) pixels will be transparent*/
+        .header.format = LV_IMG_FORMAT_INTERNAL_RAW,
     },
     {
-    .pixel_map = apple_icon_chroma_pixel_map, /*Pointer the array of image pixels.*/
+        .pixel_map = apple_icon_chroma_pixel_map, /*Pointer the array of image pixels.*/
     }
 };
 

--- a/lv_tutorial/5_antialiasing/apple_icon_chroma.c
+++ b/lv_tutorial/5_antialiasing/apple_icon_chroma.c
@@ -116,12 +116,16 @@ static const uint8_t apple_icon_chroma_pixel_map[] = {
 
 
 const lv_img_t apple_icon_chroma = {
+    {
     .header.w = 30,           /*Image width in pixel count*/
     .header.h = 30,           /*Image height in pixel count*/
     .header.alpha_byte = 0,       /*No alpha byte*/
     .header.chroma_keyed = 1, /*LV_COLOR_TRANSP (lv_conf.h) pixels will be transparent*/
     .header.format = LV_IMG_FORMAT_INTERNAL_RAW,
+    },
+    {
     .pixel_map = apple_icon_chroma_pixel_map, /*Pointer the array of image pixels.*/
+    }
 };
 
 #endif

--- a/lv_tutorial/6_images/red_flower.c
+++ b/lv_tutorial/6_images/red_flower.c
@@ -252,14 +252,14 @@ static const uint8_t red_flower_pixel_map[] = {
 
 const lv_img_t red_flower = {
     {
-    .header.w = 100,          /*Image width in pixel count*/
-    .header.h = 75,           /*Image height in pixel count*/
-    .header.alpha_byte = 0,       /*No alpha byte*/
-    .header.chroma_keyed = 0, /*No chroma keying*/
-    .header.format = LV_IMG_FORMAT_INTERNAL_RAW,  /*It's a variable compiled into the code*/
+        .header.w = 100,          /*Image width in pixel count*/
+        .header.h = 75,           /*Image height in pixel count*/
+        .header.alpha_byte = 0,       /*No alpha byte*/
+        .header.chroma_keyed = 0, /*No chroma keying*/
+        .header.format = LV_IMG_FORMAT_INTERNAL_RAW,  /*It's a variable compiled into the code*/
     },
     {
-    .pixel_map = red_flower_pixel_map /*Pointer the array of image pixels.*/
+        .pixel_map = red_flower_pixel_map /*Pointer the array of image pixels.*/
     }
 };
 

--- a/lv_tutorial/6_images/red_flower.c
+++ b/lv_tutorial/6_images/red_flower.c
@@ -251,12 +251,16 @@ static const uint8_t red_flower_pixel_map[] = {
 
 
 const lv_img_t red_flower = {
+    {
     .header.w = 100,          /*Image width in pixel count*/
     .header.h = 75,           /*Image height in pixel count*/
     .header.alpha_byte = 0,       /*No alpha byte*/
     .header.chroma_keyed = 0, /*No chroma keying*/
     .header.format = LV_IMG_FORMAT_INTERNAL_RAW,  /*It's a variable compiled into the code*/
+    },
+    {
     .pixel_map = red_flower_pixel_map /*Pointer the array of image pixels.*/
+    }
 };
 
 #endif


### PR DESCRIPTION
1. Workaround fixes for code causing compile-time errors related to a bug in gcc versions <4.6 (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=10676).
2. Formatting code to project coding style (mostly changing tabs to 4 spaces)