### PR TITLE
Fix crash in lv_test_theme_2 when all themes are not enabled

### DIFF
--- a/lv_tests/lv_test_theme/lv_test_theme_2.c
+++ b/lv_tests/lv_test_theme/lv_test_theme_2.c
@@ -311,32 +311,34 @@ static lv_res_t hue_select_action(lv_obj_t * roller)
 
 static void init_all_themes(uint16_t hue)
 {
+    /* NOTE: This must be adjusted if there are more than 8 themes. */
+    int i = 0;
 #if USE_LV_THEME_NIGHT
-    themes[0] = lv_theme_night_init(hue, NULL);
+    themes[i++] = lv_theme_night_init(hue, NULL);
 #endif
 
 #if USE_LV_THEME_MATERIAL
-    themes[1] = lv_theme_material_init(hue, NULL);
+    themes[i++] = lv_theme_material_init(hue, NULL);
 #endif
 
 #if USE_LV_THEME_ALIEN
-    themes[2] = lv_theme_alien_init(hue, NULL);
+    themes[i++] = lv_theme_alien_init(hue, NULL);
 #endif
 
 #if USE_LV_THEME_ZEN
-    themes[3] = lv_theme_zen_init(hue, NULL);
+    themes[i++] = lv_theme_zen_init(hue, NULL);
 #endif
 
 #if USE_LV_THEME_NEMO
-    themes[4] = lv_theme_nemo_init(hue, NULL);
+    themes[i++] = lv_theme_nemo_init(hue, NULL);
 #endif
 
 #if USE_LV_THEME_MONO
-    themes[5] = lv_theme_mono_init(hue, NULL);
+    themes[i++] = lv_theme_mono_init(hue, NULL);
 #endif
 
 #if USE_LV_THEME_DEFAULT
-    themes[6] = lv_theme_default_init(hue, NULL);
+    themes[i++] = lv_theme_default_init(hue, NULL);
 #endif
 }
 

--- a/lv_tests/lv_test_theme/lv_test_theme_2.c
+++ b/lv_tests/lv_test_theme/lv_test_theme_2.c
@@ -311,7 +311,7 @@ static lv_res_t hue_select_action(lv_obj_t * roller)
 
 static void init_all_themes(uint16_t hue)
 {
-    /* NOTE: This must be adjusted if there are more than 8 themes. */
+    /* NOTE: This must be adjusted if more themes are added. */
     int i = 0;
 #if USE_LV_THEME_NIGHT
     themes[i++] = lv_theme_night_init(hue, NULL);


### PR DESCRIPTION
The previous algorithm assumed that the theme roller action skips over index values, which is not the case.

I updated the function to instead pack all themes against the beginning of the array, which is the layout the theme roller action expects.