### PR TITLE
demo_stress: Fix typo

### DIFF
--- a/src/lv_demo_stress/lv_demo_stress.h
+++ b/src/lv_demo_stress/lv_demo_stress.h
@@ -1,5 +1,5 @@
 /**
- * @file lv_demo_widgets.h
+ * @file lv_demo_stress.h
  *
  */
 
@@ -25,7 +25,7 @@ extern "C" {
 /**********************
  * GLOBAL PROTOTYPES
  **********************/
-void lv_demo_widgets(void);
+void lv_demo_stress(void);
 
 /**********************
  *      MACROS


### PR DESCRIPTION
demo stress header file exposes a function named `lv_demo_widgets` instead of `lv_demo_stress`.